### PR TITLE
Refactor: Detail Page - Card 컴포넌트 분리 및 반응형 적용 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.52.0",
         "react-modal": "^3.16.1",
-        "react-router-dom": "^6.23.1"
+        "react-router-dom": "^6.23.1",
+        "tailwind-scrollbar-hide": "^1.1.7"
       },
       "devDependencies": {
         "@types/node": "^20.14.2",
@@ -39,7 +40,7 @@
         "eslint-plugin-react-refresh": "^0.4.6",
         "husky": "^8.0.0",
         "lint-staged": "^15.2.7",
-        "mingle-ui": "^0.1.7",
+        "mingle-ui": "^0.2.0",
         "postcss": "^8.4.38",
         "prettier": "^3.3.2",
         "prettier-plugin-tailwindcss": "^0.6.4",
@@ -4895,12 +4896,13 @@
       }
     },
     "node_modules/mingle-ui": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/mingle-ui/-/mingle-ui-0.1.7.tgz",
-      "integrity": "sha512-67AORC5NolrQWC4TWTV8ZK7mSpK/q148p+cDf/MOZuIePmiNOlOOG6q8kTAJMECT2cBm1++bgJVt9DyHUgbncQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mingle-ui/-/mingle-ui-0.2.0.tgz",
+      "integrity": "sha512-i2y91kZvWHPuGBXFejNk351DlYLc6hCTX4q33fuRUaRUXDeSedHuJXSzSXeIWrT3S9bxLTcU6//Fk3XKsQOxpw==",
       "dev": true,
       "dependencies": {
         "@fontsource/plus-jakarta-sans": "^5.0.20",
+        "dayjs": "^1.11.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.51.5",
@@ -6497,6 +6499,11 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA=="
     },
     "node_modules/tailwindcss": {
       "version": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.52.0",
     "react-modal": "^3.16.1",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "tailwind-scrollbar-hide": "^1.1.7"
   },
   "devDependencies": {
     "@types/node": "^20.14.2",
@@ -43,7 +44,7 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "husky": "^8.0.0",
     "lint-staged": "^15.2.7",
-    "mingle-ui": "^0.1.7",
+    "mingle-ui": "^0.2.0",
     "postcss": "^8.4.38",
     "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.4",

--- a/src/components/pages/DetailBoard/BoardCount.tsx
+++ b/src/components/pages/DetailBoard/BoardCount.tsx
@@ -5,7 +5,7 @@ type BoardCountProps = {
 
 const BoardCount = ({ paperCount, reactionCount }: BoardCountProps) => {
   return (
-    <ul className='board-count flex gap-6'>
+    <ul className='board-count flex w-full gap-6'>
       <li className='flex items-center gap-2'>
         <span className='text-base-14 text-neutral-500'>Paper</span>
         <span className='text-bold-18'>{paperCount}</span>

--- a/src/components/pages/DetailBoard/CardList.tsx
+++ b/src/components/pages/DetailBoard/CardList.tsx
@@ -1,0 +1,42 @@
+import { CardSkeleton, EmptyCard, PaperCard } from 'mingle-ui';
+
+import { TRANSLATE_TO_EN } from '@/constants';
+
+import { MessagesResults, PaperCardResults } from '@/types/recipients';
+
+interface CardListProps {
+  isMessagesLoading: boolean;
+  filteredMessages: MessagesResults[];
+}
+
+const CardList = ({ isMessagesLoading, filteredMessages }: CardListProps) => {
+  const isEmpty = filteredMessages?.length === 0;
+
+  return (
+    <ul className='grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3'>
+      {isMessagesLoading ? (
+        Array.from({ length: 9 }).map((_, idx: number) => (
+          <li key={`empty-card-${idx}`}>
+            <CardSkeleton />
+          </li>
+        ))
+      ) : isEmpty ? (
+        <EmptyCard />
+      ) : (
+        filteredMessages?.map(({ id, sender, relationship, content, profileImageURL, createdAt }: PaperCardResults) => (
+          <li key={`paper-card-${id}`} className='relative'>
+            <PaperCard
+              fromName={sender}
+              category={TRANSLATE_TO_EN[relationship]}
+              description={content}
+              backgroundImage={profileImageURL}
+              createdAt={createdAt}
+            />
+          </li>
+        ))
+      )}
+    </ul>
+  );
+};
+
+export default CardList;

--- a/src/components/pages/DetailBoard/EmojiList.tsx
+++ b/src/components/pages/DetailBoard/EmojiList.tsx
@@ -37,7 +37,7 @@ const EmojiList = ({ boardId }: EmojiListProps) => {
 
   return (
     <div className='flex w-full flex-row-reverse items-center gap-2 md:flex-row md:justify-end'>
-      <ul className='flex gap-2 sm-scroll-hidden'>
+      <ul className='flex w-full gap-2 sm-scroll-hidden md:justify-end'>
         {emojiList?.map(({ id, emoji, count }: EmojiResults) => (
           <li key={`emoji-badge-${id}`}>
             <BadgeEmoji emoji={emoji} count={count} />

--- a/src/components/pages/DetailBoard/EmojiList.tsx
+++ b/src/components/pages/DetailBoard/EmojiList.tsx
@@ -2,7 +2,9 @@ import EmojiPicker, { EmojiClickData, EmojiStyle, Theme } from 'emoji-picker-rea
 import { BadgeEmoji, IconButton } from 'mingle-ui';
 
 import { SVGS } from '@/constants';
+import { getReactionsByDeviceType } from '@/utils';
 
+import { useDeviceType } from '@/hooks/useDeviceType';
 import useTogglePopup from '@/hooks/useTogglePopup';
 import { useCreateEmoji } from '@/pages/DetailBoard/service/useCreateEmoji';
 import { useGetEmoji } from '@/pages/DetailBoard/service/useGetEmoji';
@@ -19,7 +21,8 @@ const EmojiList = ({ boardId }: EmojiListProps) => {
   const { EmojiData } = useGetEmoji(boardId);
   const { postEmojiMutation } = useCreateEmoji(boardId);
 
-  const topRection = EmojiData?.slice(0, 3);
+  const deviceType = useDeviceType();
+  const emojiList = getReactionsByDeviceType(deviceType, EmojiData);
 
   const handleEmojiClick = (event: EmojiClickData) => {
     const emojiForm: PostEmoji = {
@@ -33,9 +36,9 @@ const EmojiList = ({ boardId }: EmojiListProps) => {
   };
 
   return (
-    <div className='emoji-list flex items-center gap-2'>
-      <ul className='flex gap-2'>
-        {topRection?.map(({ id, emoji, count }: EmojiResults) => (
+    <div className='flex w-full flex-row-reverse items-center gap-2 md:flex-row md:justify-end'>
+      <ul className='flex gap-2 sm-scroll-hidden'>
+        {emojiList?.map(({ id, emoji, count }: EmojiResults) => (
           <li key={`emoji-badge-${id}`}>
             <BadgeEmoji emoji={emoji} count={count} />
           </li>
@@ -52,7 +55,7 @@ const EmojiList = ({ boardId }: EmojiListProps) => {
           onClick={togglePopup}
         />
         {isOpen && (
-          <div ref={popupRef} className='absolute right-0 top-11 z-10'>
+          <div ref={popupRef} className='absolute right-0 top-11 z-20'>
             <EmojiPicker
               theme={Theme.DARK}
               emojiStyle={EmojiStyle.APPLE}

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -12,7 +12,7 @@ const Header = () => {
   const location = useLocation();
 
   return (
-    <header className='header-background fixed left-0 top-0 z-50 flex h-[64px] w-full items-center justify-between px-10'>
+    <header className='header-background fixed left-0 top-0 z-50 flex h-[64px] w-full items-center justify-between px-5 lg:px-10'>
       <h1>
         <Link to={landing}>
           <img src={url} alt={alt} />

--- a/src/constants/breakpoint.ts
+++ b/src/constants/breakpoint.ts
@@ -1,0 +1,6 @@
+export const BREAK_POINT = {
+  pc: 1919,
+  laptop: 1283,
+  tablet: 1023,
+  mobile: 767,
+};

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -30,7 +30,7 @@ export const PAPER_BACKGROUND_IMAGES = [
   {
     id: 'pika',
     type: 'backgroundImageURL',
-    value: `${CLOUDFLARE_URL}/278f93ac-551e-4d82-6dd3-5b67513c2e00/${PREVIEW_PAPER_SIZE}`,
+    value: `${CLOUDFLARE_URL}/650bcaca-3f77-4ebb-5907-7e9e2436af00/${PREVIEW_PAPER_SIZE}`,
   },
   {
     id: 'mario',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,3 +4,4 @@ export * from './navList';
 export * from './tabList';
 export * from './endpoints';
 export * from './translateToAuth';
+export * from './breakpoint';

--- a/src/hooks/useDeviceType.ts
+++ b/src/hooks/useDeviceType.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+import { BREAK_POINT } from '@/constants';
+
+import { DeviceType } from '@/types/deviceType';
+
+export const useDeviceType = (): DeviceType => {
+  const detectDeviceType = (): DeviceType => {
+    const windowWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
+
+    if (windowWidth <= BREAK_POINT.mobile) {
+      return DeviceType.sm;
+    }
+
+    if (windowWidth <= BREAK_POINT.tablet) {
+      return DeviceType.md;
+    }
+
+    if (windowWidth <= BREAK_POINT.pc) {
+      return DeviceType.lg;
+    }
+    return DeviceType.xl;
+  };
+
+  const [currentDeviceType, setCurrentDeviceType] = useState<DeviceType>(DeviceType.xl);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const newDeviceType = detectDeviceType();
+      setCurrentDeviceType(newDeviceType);
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return currentDeviceType;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -51,4 +51,42 @@
   .base-transition {
     @apply transition-all duration-300 ease-in-out;
   }
+
+  .flexbox-column {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .flexbox-column-center {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .flexbox-column-start {
+    display: flex;
+    flex-direction: column;
+    justify-content: start;
+    align-items: start;
+  }
+
+  .flexbox-row {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .flexbox-row-between {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .flexbox-row-center {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  }
 }

--- a/src/pages/DetailBoard/index.tsx
+++ b/src/pages/DetailBoard/index.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import { Dropdown, IconButton, PaperCard, TabList, EmptyCard } from 'mingle-ui';
+import { Dropdown, IconButton, TabList, PrimaryButton } from 'mingle-ui';
 import { useParams } from 'react-router-dom';
 
 import { AUTHOR_LIST, SORT_OPTIONS, SVGS, TRANSLATE_TO_EN } from '@/constants';
 
 import BoardCount from '@/components/pages/DetailBoard/BoardCount';
+import CardList from '@/components/pages/DetailBoard/CardList';
 import EmojiList from '@/components/pages/DetailBoard/EmojiList';
 import Header from '@/components/ui/Header';
 import { MessagesResults, PaperCardResults } from '@/types/recipients';
@@ -25,12 +26,14 @@ const DetailBoard = () => {
   const [selectedTab, setSelectedTab] = useState(AUTHOR_LIST[0].id);
   const [selectedSortOption, setSelectedSortOption] = useState(SORT_OPTIONS[0].id);
 
-  const filterdMessages = useMemo(() => {
-    const filtered = messageData?.filter((messageData: PaperCardResults) => {
-      return selectedTab === 'all' || messageData?.relationship === selectedTab;
+  const filteredMessages = useMemo(() => {
+    if (!messageData) return [];
+
+    const filtered = messageData.filter((messageData: PaperCardResults) => {
+      return selectedTab === 'all' || messageData.relationship === selectedTab;
     });
 
-    const sorted = filtered?.sort((a: MessagesResults, b: MessagesResults) => {
+    const sorted = filtered.sort((a: MessagesResults, b: MessagesResults) => {
       const dateA = new Date(a.createdAt).getTime();
       const dateB = new Date(b.createdAt).getTime();
       return selectedSortOption === 'desc' ? dateB - dateA : dateA - dateB;
@@ -44,56 +47,44 @@ const DetailBoard = () => {
       <Header />
       <main className='py-[100px]'>
         <div>
-          <div className='m-auto flex max-w-[1120px] flex-col gap-1'>
+          <div className='m-auto flex max-w-[1120px] flex-col gap-2 px-5 lg:px-10'>
             <div className='flex items-center gap-1'>
               <h2 className='text-bold-24'>{boardData?.name}</h2>
               <IconButton iconUrl={setting.url} iconAlt={setting.alt} iconSize={20} onClick={() => {}} />
             </div>
 
-            <div className='flex items-center justify-between'>
+            <div className='flexbox-column-start md:!flexbox-row-between gap-3'>
               <BoardCount paperCount={boardData?.messageCount} reactionCount={boardData?.reactionCount} />
               <EmojiList boardId={boardId} />
             </div>
           </div>
 
-          <div className='mt-6 h-[52px] w-full border-y border-neutral-800'>
-            <div className='m-auto max-w-[1120px]'>
+          <div className='mt-6 h-[52px] w-full border-y border-neutral-800 lg:px-10'>
+            <div className='m-auto max-w-[1120px] sm-scroll-hidden'>
               <TabList tabList={AUTHOR_LIST} size='lg' onClick={setSelectedTab} />
             </div>
           </div>
 
-          <section className='m-auto max-w-[1120px]'>
+          <section className='m-auto max-w-[1120px] px-5 lg:px-10'>
             <div className='flex items-center justify-between py-6'>
               <div className='flex items-center gap-2'>
                 <span className='text-bold-18'>{TRANSLATE_TO_EN[selectedTab]}</span>
-                <span className='mt-[2px] text-bold-13 text-yellow-300'>{filterdMessages?.length}</span>
+                <span className='mt-[2px] text-bold-13 text-yellow-300'>{filteredMessages?.length}</span>
               </div>
+
               <div className='relative flex gap-2'>
-                <div className='absolute -left-[120px] max-w-[112px]'>
+                <div className='absolute -left-[120px] z-10 max-w-[112px]'>
                   <Dropdown size='sm' selectList={SORT_OPTIONS} onClick={setSelectedSortOption} />
                 </div>
                 <IconButton iconUrl={kakao.url} iconAlt={kakao.alt} iconSize={20} variant='stroke' onClick={() => {}} />
               </div>
             </div>
-            <ul className='grid grid-cols-3 gap-5'>
-              {isMessagesLoading
-                ? Array.from({ length: 9 }).map((_, idx: number) => (
-                    <li key={`empty-card-${idx}`}>
-                      <EmptyCard />
-                    </li>
-                  ))
-                : filterdMessages?.map(({ id, sender, relationship, content, profileImageURL }: PaperCardResults) => (
-                    <li key={`paper-card-${id}`}>
-                      <PaperCard
-                        fromName={sender}
-                        category={TRANSLATE_TO_EN[relationship]}
-                        description={content}
-                        backgroundImage={profileImageURL}
-                      />
-                    </li>
-                  ))}
-            </ul>
+
+            <CardList isMessagesLoading={isMessagesLoading} filteredMessages={filteredMessages} />
           </section>
+          <div className='fixed bottom-5 left-0 right-0 m-auto max-w-[800px] px-5'>
+            <PrimaryButton size='lg'>Add Paper</PrimaryButton>
+          </div>
         </div>
       </main>
     </div>

--- a/src/types/deviceType.ts
+++ b/src/types/deviceType.ts
@@ -1,0 +1,6 @@
+export enum DeviceType {
+  sm = 'Mobile',
+  md = 'Tablet',
+  lg = 'Laptop',
+  xl = 'PC',
+}

--- a/src/types/recipients.ts
+++ b/src/types/recipients.ts
@@ -15,6 +15,7 @@ export type PaperCardResults = {
   relationship: string;
   content: string;
   profileImageURL: string;
+  createdAt: string;
 };
 
 export type MessagesResults = {

--- a/src/utils/getReactionsByDeviceType.ts
+++ b/src/utils/getReactionsByDeviceType.ts
@@ -1,8 +1,11 @@
 import { DeviceType } from '@/types/deviceType';
 import { EmojiResults } from '@/types/recipients';
 
+const TOP_REACTIONS = 3;
+const MAX_REACRIONS = 8;
+
 export const getReactionsByDeviceType = (deviceType: DeviceType, reactionData: EmojiResults[]) => {
-  const topRection = reactionData?.slice(0, 3);
-  const maxReaction = reactionData?.slice(0, 8);
+  const topRection = reactionData?.slice(0, TOP_REACTIONS);
+  const maxReaction = reactionData?.slice(0, MAX_REACRIONS);
   return deviceType !== 'Mobile' ? topRection : maxReaction;
 };

--- a/src/utils/getReactionsByDeviceType.ts
+++ b/src/utils/getReactionsByDeviceType.ts
@@ -1,0 +1,8 @@
+import { DeviceType } from '@/types/deviceType';
+import { EmojiResults } from '@/types/recipients';
+
+export const getReactionsByDeviceType = (deviceType: DeviceType, reactionData: EmojiResults[]) => {
+  const topRection = reactionData?.slice(0, 3);
+  const maxReaction = reactionData?.slice(0, 8);
+  return deviceType !== 'Mobile' ? topRection : maxReaction;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './getReactionsByDeviceType';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -130,20 +130,9 @@ export default {
     },
   },
   plugins: [
+    require('tailwind-scrollbar-hide'),
     function ({ addUtilities }) {
       addUtilities({
-        '.flexbox-column': {
-          '@apply flex flex-col': '',
-        },
-        '.flexbox-column-center': {
-          '@apply flex flex-col items-center justify-center': '',
-        },
-        '.flexbox-row': {
-          '@apply flex flex-row': '',
-        },
-        '.flexbox-row-center': {
-          '@apply flex flex-row items-center justify-center': '',
-        },
         '.color-text-primary': {
           '@apply text-neutral-200': '',
         },
@@ -152,6 +141,9 @@ export default {
         },
         '.color-background-opacity-black-30': {
           '@apply bg-black bg-opacity-30': '',
+        },
+        '.sm-scroll-hidden': {
+          '@apply overflow-scroll scrollbar-hide': '',
         },
       });
     },


### PR DESCRIPTION
## 유형

- [x] UI 구현
- [ ] 기능 구현
- [ ] 버그 해결
- [ ] 문서 업데이트
- [x] 리팩터링

## 상세 내용

### 📌 기능 구현
- useDeviceType
   : window 크기에 따라 디바이스 타입을 반환하는 훅을 구현했습니다.
- getReactionsByDeviceType
   : 디바이스 크기에 따라 이모지 리스트의 개수를 변환하는 유틸 함수를 추가했습니다.
   : Mobile 이상 디바이스에서는 이모지 리스트에서 상위 3개의 이모지를 보여줍니다.
   : Mobile 디바이스에서는 최대 8개의 이모지를 좌우 스크롤 가능한 형태로 보여줍니다.
- CardList 컴포넌트 구현
- New 태그 반영
  : createdAt 타입을 선언하고, 이를 props로 내려주도록 변경했습니다.
- Add Paper 버튼
   : 페이퍼 추가하기 버튼을 디바이스 하단에 고정(fixed)되도록 구현했습니다.
- Flex 관련 클래스를 index.css 파일로 일괄 이동했습니다.
- tailwind-scrollbar-hide 패키지 적용

## 스크린샷

### 📌 PC

<img width="1889" alt="image" src="https://github.com/designsoo/mingle/assets/77719310/9b1809cb-0d76-4b23-8ef7-e246f441f811">

### 📌 Tablet

<img width="764" alt="image" src="https://github.com/designsoo/mingle/assets/77719310/b572444b-971f-4b6a-9d69-c76f9c6432a6">

### 📌 Mobile

<img width="370" alt="image" src="https://github.com/designsoo/mingle/assets/77719310/fe447620-e603-4f5f-a0d6-cbaf1008a1e1">



