### PR TITLE
Refactor: 상세보기 페이지에 적용되는 모달 컴포넌트 분리, 스켈레톤 컴포넌트 적용

### DIFF
--- a/src/components/pages/DetailBoard/BoardName.tsx
+++ b/src/components/pages/DetailBoard/BoardName.tsx
@@ -1,0 +1,45 @@
+import { IconButton } from 'mingle-ui';
+import { useNavigate } from 'react-router-dom';
+
+import { SVGS } from '@/constants';
+
+const { setting } = SVGS;
+
+interface BoardNameProps {
+  isEdit: boolean;
+  name: string | undefined;
+  boardId: number;
+}
+
+const BoardName = ({ isEdit, name, boardId }: BoardNameProps) => {
+  const navigate = useNavigate();
+
+  const navigateToEditPage = () => navigate(`/board/${boardId}/edit`);
+  const navigateToDetailPage = () => navigate(`/board/${boardId}`);
+
+  return (
+    <>
+      <div className='flex items-center gap-1'>
+        <h2 className='text-bold-24'>{name}</h2>
+
+        {isEdit ? (
+          <IconButton
+            iconUrl={setting.active.url}
+            iconAlt={setting.active.alt}
+            iconSize={20}
+            onClick={navigateToDetailPage}
+          />
+        ) : (
+          <IconButton
+            iconUrl={setting.default.url}
+            iconAlt={setting.default.alt}
+            iconSize={20}
+            onClick={navigateToEditPage}
+          />
+        )}
+      </div>
+    </>
+  );
+};
+
+export default BoardName;

--- a/src/components/pages/DetailBoard/BoardSkeleton.tsx
+++ b/src/components/pages/DetailBoard/BoardSkeleton.tsx
@@ -1,0 +1,15 @@
+const BoardSkeleton = () => {
+  return (
+    <>
+      <div className='m-auto flex max-w-[1120px] flex-col gap-2 px-5 lg:px-10 xl:px-0'>
+        <div className='h-8 w-[160px] animate-pulse rounded-lg bg-neutral-800'></div>
+        <div className='flexbox-column-start md:!flexbox-row-between gap-3 md:h-9'>
+          <div className='h-8 w-[250px] animate-pulse rounded-lg bg-neutral-800'></div>
+          <div className='h-8 w-[160px] animate-pulse rounded-lg bg-neutral-800'></div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default BoardSkeleton;

--- a/src/components/pages/DetailBoard/CardList.tsx
+++ b/src/components/pages/DetailBoard/CardList.tsx
@@ -1,29 +1,21 @@
 import { useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import {
-  CardSkeleton,
-  EmptyCard,
-  Input,
-  ErrorMessage,
-  PaperCard,
-  PrimaryButton,
-  CommonModal,
-  ConfirmModal,
-} from 'mingle-ui';
-import { FieldError, FormProvider, useForm } from 'react-hook-form';
+import { EmptyCard, PaperCard } from 'mingle-ui';
+import { useForm } from 'react-hook-form';
 
-import { TRANSLATE_TO_EN, SVGS } from '@/constants';
+import { TRANSLATE_TO_EN } from '@/constants';
 import { splitByDelimiter } from '@/utils';
 
+import CardListSkeleton from '@/components/pages/detailBoard/CardListSkeleton';
+import ConfirmDeleteModal from '@/components/pages/detailBoard/ConfirmDeleteModal';
+import DeleteCardButton from '@/components/pages/detailBoard/DeleteCardButton';
 import useMultiState from '@/hooks/useMultiState';
 import { useDeleteCard } from '@/pages/EditBoard/data-access/useDeleteCard';
 import { passwordSchema } from '@/pages/EditBoard/schema/passwordSchema';
 import { MessagesResults, PaperCardResults } from '@/types/recipients';
 
-import DeleteCardButton from './DeleteCardButton';
-
-const { delete: removeIcon } = SVGS;
+import ConfirmPasswordModal from './ConfirmPasswordModal';
 
 interface CardListProps {
   isEdit: boolean;
@@ -44,11 +36,7 @@ const CardList = ({ isEdit, boardId, isMessagesLoading, filteredMessages }: Card
     resolver: zodResolver(passwordSchema(password)),
   });
 
-  const {
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = methods;
+  const { reset } = methods;
 
   const isEmpty = filteredMessages?.length === 0;
 
@@ -84,13 +72,9 @@ const CardList = ({ isEdit, boardId, isMessagesLoading, filteredMessages }: Card
   return (
     <>
       <ul className='grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3'>
-        {isMessagesLoading ? (
-          Array.from({ length: 9 }).map((_, idx: number) => (
-            <li key={`empty-card-${idx}`}>
-              <CardSkeleton />
-            </li>
-          ))
-        ) : isEmpty ? (
+        {isMessagesLoading && <CardListSkeleton />}
+
+        {isEmpty ? (
           <EmptyCard />
         ) : (
           filteredMessages?.map(
@@ -118,56 +102,18 @@ const CardList = ({ isEdit, boardId, isMessagesLoading, filteredMessages }: Card
         )}
       </ul>
 
-      <CommonModal
-        openModal={multiState.confirmPasswordModal}
+      <ConfirmPasswordModal
+        formMethods={methods}
+        isOpenPasswordModal={multiState.confirmPasswordModal}
         onClose={handleToggleConfirmPasswordModal}
-        title='Confirm Password'
-      >
-        <div className='flex w-full flex-col items-end gap-6'>
-          <FormProvider {...methods}>
-            <form onSubmit={handleSubmit(onSubmit)} className='flex w-full flex-col items-end gap-6 md:w-[400px]'>
-              <div className='flex w-full flex-col gap-2'>
-                <Input
-                  formMethod={methods}
-                  name='password'
-                  placeholder='● ● ● ●'
-                  type='password'
-                  maxLength={4}
-                  autoComplete='current-password'
-                />
-                {errors?.password && <ErrorMessage>{(errors.password as FieldError).message}</ErrorMessage>}
-              </div>
-              <div className='flex gap-3'>
-                <PrimaryButton variant='stroke' onClick={handleToggleConfirmPasswordModal}>
-                  Cancel
-                </PrimaryButton>
-                <PrimaryButton variant='destructive' type='submit'>
-                  Delete
-                </PrimaryButton>
-              </div>
-            </form>
-          </FormProvider>
-        </div>
-      </CommonModal>
+        onSubmit={onSubmit}
+      />
 
-      <ConfirmModal
-        openModal={multiState.confirmDeleteModal}
+      <ConfirmDeleteModal
+        isOpenDeleteModal={multiState.confirmDeleteModal}
         onClose={handleToggleConfirmDeletedModal}
-        iconUrl={removeIcon.active.url}
-        iconAlt={removeIcon.active.alt}
-        iconSize={58}
-        title='Are you sure'
-        desc='This action cannot be undone.'
-      >
-        <div className='flex gap-3'>
-          <PrimaryButton variant='stroke' onClick={handleToggleConfirmDeletedModal}>
-            Cancel
-          </PrimaryButton>
-          <PrimaryButton variant='destructive' onClick={handleDeleteCard}>
-            Delete
-          </PrimaryButton>
-        </div>
-      </ConfirmModal>
+        handleDeleteCard={handleDeleteCard}
+      />
     </>
   );
 };

--- a/src/components/pages/DetailBoard/CardListSkeleton.tsx
+++ b/src/components/pages/DetailBoard/CardListSkeleton.tsx
@@ -1,0 +1,11 @@
+import { CardSkeleton } from 'mingle-ui';
+
+const CardListSkeleton = () => {
+  return Array.from({ length: 9 }).map((_, idx: number) => (
+    <li key={`empty-card-${idx}`}>
+      <CardSkeleton />
+    </li>
+  ));
+};
+
+export default CardListSkeleton;

--- a/src/components/pages/DetailBoard/ConfirmDeleteModal.tsx
+++ b/src/components/pages/DetailBoard/ConfirmDeleteModal.tsx
@@ -1,0 +1,35 @@
+import { ConfirmModal, PrimaryButton } from 'mingle-ui';
+
+import { SVGS } from '@/constants';
+const { delete: removeIcon } = SVGS;
+
+interface ConfirmDeleteModalProps {
+  isOpenDeleteModal: boolean;
+  onClose: () => void;
+  handleDeleteCard: () => void;
+}
+
+const ConfirmDeleteModal = ({ isOpenDeleteModal, onClose, handleDeleteCard }: ConfirmDeleteModalProps) => {
+  return (
+    <ConfirmModal
+      openModal={isOpenDeleteModal}
+      onClose={onClose}
+      iconUrl={removeIcon.active.url}
+      iconAlt={removeIcon.active.alt}
+      iconSize={58}
+      title='Are you sure'
+      desc='This action cannot be undone.'
+    >
+      <div className='flex gap-3'>
+        <PrimaryButton variant='stroke' onClick={onClose}>
+          Cancel
+        </PrimaryButton>
+        <PrimaryButton variant='destructive' onClick={handleDeleteCard}>
+          Delete
+        </PrimaryButton>
+      </div>
+    </ConfirmModal>
+  );
+};
+
+export default ConfirmDeleteModal;

--- a/src/components/pages/DetailBoard/ConfirmPasswordModal.tsx
+++ b/src/components/pages/DetailBoard/ConfirmPasswordModal.tsx
@@ -1,0 +1,48 @@
+import { CommonModal, ErrorMessage, Input, PrimaryButton } from 'mingle-ui';
+import { FieldError, FormProvider, UseFormReturn } from 'react-hook-form';
+
+interface ConfirmPasswordModalProps {
+  formMethods: UseFormReturn;
+  isOpenPasswordModal: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+const ConfirmPasswordModal = ({ formMethods, isOpenPasswordModal, onClose, onSubmit }: ConfirmPasswordModalProps) => {
+  const {
+    handleSubmit,
+    formState: { errors },
+  } = formMethods;
+
+  return (
+    <CommonModal openModal={isOpenPasswordModal} onClose={onClose} title='Confirm Password'>
+      <div className='flex w-full flex-col items-end gap-6'>
+        <FormProvider {...formMethods}>
+          <form onSubmit={handleSubmit(onSubmit)} className='flex w-full flex-col items-end gap-6 md:w-[400px]'>
+            <div className='flex w-full flex-col gap-2'>
+              <Input
+                formMethod={formMethods}
+                name='password'
+                placeholder='● ● ● ●'
+                type='password'
+                maxLength={4}
+                autoComplete='current-password'
+              />
+              {errors?.password && <ErrorMessage>{(errors.password as FieldError).message}</ErrorMessage>}
+            </div>
+            <div className='flex gap-3'>
+              <PrimaryButton variant='stroke' onClick={onClose}>
+                Cancel
+              </PrimaryButton>
+              <PrimaryButton variant='destructive' type='submit'>
+                Delete
+              </PrimaryButton>
+            </div>
+          </form>
+        </FormProvider>
+      </div>
+    </CommonModal>
+  );
+};
+
+export default ConfirmPasswordModal;

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -15,7 +15,7 @@ const Header = () => {
     <header className='header-background fixed left-0 top-0 z-50 flex h-[64px] w-full items-center justify-between px-5 lg:px-10'>
       <h1>
         <Link to={landing}>
-          <img src={url} alt={alt} />
+          <img src={url} alt={alt} width={100} height={30} />
         </Link>
       </h1>
       <nav className='flex flex-row gap-8'>

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -54,7 +54,7 @@ export const PNGS = {
 
 export const SVGS = {
   logo: {
-    url: `${CLOUDFLARE_URL}/b571045b-4bb3-4222-36d5-8557bcf7f300/width=72,height=24`,
+    url: `${CLOUDFLARE_URL}/64c2ebd4-300b-405f-1de0-664672b8d100/width=124,height=36`,
     alt: 'mingle logo',
   },
   add: {

--- a/src/index.css
+++ b/src/index.css
@@ -130,21 +130,6 @@
   .quill-error {
     @apply base-transition rounded-lg border border-yellow-300;
   }
-
-  .body-scrollbar {
-    &::-webkit-scrollbar {
-      width: 10px;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      background-color: red;
-      border-radius: 10px;
-    }
-
-    &::-webkit-scrollbar-track {
-      background-color: black;
-    }
-  }
 }
 
 #toolbar {

--- a/src/pages/DetailBoard/data-access/useGetBoardData.ts
+++ b/src/pages/DetailBoard/data-access/useGetBoardData.ts
@@ -3,10 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 import { getBoard } from '@/api/queryFunctions';
 
 export const useGetBoardData = (boardId: number) => {
-  const { data: boardData } = useQuery({
+  const { data: boardData, isLoading: isBoardDataLoading } = useQuery({
     queryKey: ['recipient', boardId],
     queryFn: () => getBoard(boardId),
   });
 
-  return { boardData };
+  return { boardData, isBoardDataLoading };
 };


### PR DESCRIPTION
## 유형

- [x] UI 구현
- [ ] 기능 구현
- [ ] 버그 해결
- [ ] 문서 업데이트
- [x] 리팩터링

## 상세 내용

- 스켈레톤 적용
  : 보드 데이터 로딩 중일 때 title, count, emoji-list, cardList에 스켈레톤을 적용했습니다.
- 비밀번호 확인 모달 컴포넌트 분리
   : 비밀번호가 필요한 경우 삭제 전에 비밀번호를 확인하는 모달창을 컴포넌트로 분리했습니다.
   : 비밀번호가 필요 없는 경우 삭제 확인 모달창을 컴포넌트로 분리했습니다.
- 상세보기 페이지와 카드 리스트에 삭제 확인 모달 및 비밀번호 확인 모달 컴포넌트를 적용했습니다.
- 사용되지 않는 body-scroll 클래스를 삭제했습니다.
