### PR TITLE
Feat: list page 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "eslint-plugin-react-refresh": "^0.4.7",
         "husky": "^8.0.0",
         "lint-staged": "^15.2.7",
-        "mingle-ui": "^0.4.2",
+        "mingle-ui": "^0.4.6",
         "postcss": "^8.4.38",
         "prettier": "^3.3.2",
         "prettier-plugin-tailwindcss": "^0.6.4",
@@ -4951,9 +4951,9 @@
       }
     },
     "node_modules/mingle-ui": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/mingle-ui/-/mingle-ui-0.4.2.tgz",
-      "integrity": "sha512-aj7DQnXkOLysD6HzvRs/1dDmvmzcWxNVvNN1Ag3tuL4VSdfgPCU9LckYTZUzyQer9REjyFDb5dgn1D5rfWwIhw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/mingle-ui/-/mingle-ui-0.4.6.tgz",
+      "integrity": "sha512-vOneAWqEVTKNRA0jIUo5NZQSaGR7EjliwhxEE58pQXwhjx3Z+HhfSQZ+ezW4qTszNJRpSSThtDZkKfd0tzlI3w==",
       "dev": true,
       "dependencies": {
         "@fontsource/plus-jakarta-sans": "^5.0.20",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-react-refresh": "^0.4.7",
     "husky": "^8.0.0",
     "lint-staged": "^15.2.7",
-    "mingle-ui": "^0.4.2",
+    "mingle-ui": "^0.4.6",
     "postcss": "^8.4.38",
     "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.4",

--- a/src/MyRouter.tsx
+++ b/src/MyRouter.tsx
@@ -3,11 +3,12 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ROUTER_PATH } from '@/constants';
 
 import AddCard from '@/pages/AddCard';
+import BoardList from '@/pages/BoardList';
 import CreateBoard from '@/pages/CreateBoard';
 import DetailBoard from '@/pages/DetailBoard';
 import EditBoard from '@/pages/EditBoard';
 
-const { createBoard, detailBoard, editBoard, addCard } = ROUTER_PATH;
+const { createBoard, detailBoard, editBoard, addCard, boardList } = ROUTER_PATH;
 
 const MyRouter = () => {
   return (
@@ -17,6 +18,7 @@ const MyRouter = () => {
         <Route path={detailBoard} element={<DetailBoard />} />
         <Route path={editBoard} element={<EditBoard />} />
         <Route path={addCard} element={<AddCard />} />
+        <Route path={boardList} element={<BoardList />} />
       </Routes>
     </Router>
   );

--- a/src/api/queryFunctions.ts
+++ b/src/api/queryFunctions.ts
@@ -1,5 +1,15 @@
 import { MESSAGES, RECIPIENTS } from './recipients';
 
+export const getBoardList = async ({
+  queryKey,
+}: {
+  queryKey: [string, (string | undefined)?, (number | undefined)?];
+}) => {
+  const [, sort, limit] = queryKey;
+  const response = await RECIPIENTS.getBoardList(sort, limit);
+  return response.data.results;
+};
+
 export const getBoard = async (boardId: number) => {
   const response = await RECIPIENTS.getBoard(boardId);
   return response.data;

--- a/src/api/queryFunctions.ts
+++ b/src/api/queryFunctions.ts
@@ -1,11 +1,8 @@
+import { BoardListParams } from '@/types/recipients';
+
 import { MESSAGES, RECIPIENTS } from './recipients';
 
-export const getBoardList = async ({
-  queryKey,
-}: {
-  queryKey: [string, (string | undefined)?, (number | undefined)?];
-}) => {
-  const [, sort, limit] = queryKey;
+export const getBoardList = async ({ sort, limit }: BoardListParams) => {
   const response = await RECIPIENTS.getBoardList(sort, limit);
   return response.data.results;
 };

--- a/src/api/recipients.ts
+++ b/src/api/recipients.ts
@@ -5,7 +5,7 @@ import { PostEmoji } from '@/types/recipients';
 import instance from './axiosInstance';
 
 export const RECIPIENTS = {
-  getBoardList: () => instance.get(RECIPIENTS_API),
+  getBoardList: (sort?: string, limit?: number) => instance.get(RECIPIENTS_API, { params: { sort, limit } }),
   getBoard: (recipientId: number) => instance.get(`${RECIPIENTS_API}${recipientId}/`),
   post: (data: object) => instance.post(RECIPIENTS_API, data),
   deleteBoard: (recipientId: number) => instance.delete(`${RECIPIENTS_API}${recipientId}/`),

--- a/src/components/pages/DetailBoard/CardList.tsx
+++ b/src/components/pages/DetailBoard/CardList.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { EmptyCard, PaperCard } from 'mingle-ui';
+import { EmptyCard, Card } from 'mingle-ui';
 import { useForm } from 'react-hook-form';
 
 import { TRANSLATE_TO_EN } from '@/constants';
@@ -13,7 +13,7 @@ import DeleteCardButton from '@/components/pages/detailBoard/DeleteCardButton';
 import useMultiState from '@/hooks/useMultiState';
 import { useDeleteCard } from '@/pages/EditBoard/data-access/useDeleteCard';
 import { passwordSchema } from '@/pages/EditBoard/schema/passwordSchema';
-import { MessagesResults, PaperCardResults } from '@/types/recipients';
+import { MessagesResults, CardResults } from '@/types/recipients';
 
 import ConfirmPasswordModal from './ConfirmPasswordModal';
 
@@ -72,13 +72,13 @@ const CardList = ({ isEdit, boardId, isMessagesLoading, filteredMessages }: Card
   return (
     <>
       <ul className='grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3'>
-        {isMessagesLoading && <CardListSkeleton />}
-
-        {isEmpty ? (
-          <EmptyCard />
+        {isMessagesLoading ? (
+          <CardListSkeleton />
         ) : (
-          filteredMessages?.map(
-            ({ id, sender, relationship, content, profileImageURL, createdAt }: PaperCardResults) => {
+          <>
+            {isEmpty && <EmptyCard />}
+
+            {filteredMessages?.map(({ id, sender, relationship, content, profileImageURL, createdAt }: CardResults) => {
               const { name, password } = splitByDelimiter(sender);
 
               return (
@@ -88,7 +88,7 @@ const CardList = ({ isEdit, boardId, isMessagesLoading, filteredMessages }: Card
                       <DeleteCardButton onClick={() => onDeleteButtonClick(id, password)} />
                     </div>
                   )}
-                  <PaperCard
+                  <Card
                     fromName={name}
                     category={TRANSLATE_TO_EN[relationship]}
                     description={content}
@@ -97,8 +97,8 @@ const CardList = ({ isEdit, boardId, isMessagesLoading, filteredMessages }: Card
                   />
                 </li>
               );
-            },
-          )
+            })}
+          </>
         )}
       </ul>
 

--- a/src/components/pages/DetailBoard/CardListSkeleton.tsx
+++ b/src/components/pages/DetailBoard/CardListSkeleton.tsx
@@ -1,7 +1,7 @@
 import { CardSkeleton } from 'mingle-ui';
 
 const CardListSkeleton = () => {
-  return Array.from({ length: 9 }).map((_, idx: number) => (
+  return Array.from({ length: 3 }).map((_, idx: number) => (
     <li key={`empty-card-${idx}`}>
       <CardSkeleton />
     </li>

--- a/src/components/pages/boardList/BoardCard.tsx
+++ b/src/components/pages/boardList/BoardCard.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
 
+import { getBackgroundImageUrl } from '@/utils';
+
 import MemberList from '@/components/pages/boardList/MemberList';
 import TopReactionList from '@/components/pages/boardList/TopReactionList';
 import { BoardResults } from '@/types/recipients';
@@ -9,18 +11,22 @@ interface BoardCardProps {
 }
 
 const BoardCard = ({ board }: BoardCardProps) => {
+  const { id, backgroundColor, backgroundImageURL, name, messageCount, topReactions } = board;
+
+  const backgroundUrl = getBackgroundImageUrl(backgroundColor, backgroundImageURL);
+
   return (
     <article
       className='base-transition h-[320px] w-[265px] overflow-hidden rounded-2xl p-4 hover:-translate-y-3'
       style={{
-        background: `url(${board.backgroundImageURL}) no-repeat center / cover`,
+        background: `url(${backgroundUrl}) no-repeat center / cover`,
       }}
     >
-      <Link to={`/board/${board.id}`} className='flex h-full w-full flex-col justify-end'>
+      <Link to={`/board/${id}`} className='flex h-full w-full flex-col justify-end'>
         <div className='board-card-inner flex h-[136px] flex-col items-start justify-between p-3'>
-          <h4 className='h-[26px] w-full text-bold-20'>{board.name}</h4>
-          <MemberList memberList={board.recentMessages} memberCount={board.messageCount} />
-          <TopReactionList topReactions={board.topReactions} />
+          <h4 className='h-[26px] w-full text-bold-20'>{name}</h4>
+          <MemberList memberList={board.recentMessages} memberCount={messageCount} />
+          <TopReactionList topReactions={topReactions} />
         </div>
       </Link>
     </article>

--- a/src/components/pages/boardList/BoardCard.tsx
+++ b/src/components/pages/boardList/BoardCard.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom';
+
+import MemberList from '@/components/pages/boardList/MemberList';
+import TopReactionList from '@/components/pages/boardList/TopReactionList';
+import { BoardResults } from '@/types/recipients';
+
+interface BoardCardProps {
+  board: BoardResults;
+}
+
+const BoardCard = ({ board }: BoardCardProps) => {
+  return (
+    <article
+      className='base-transition h-[320px] w-[265px] overflow-hidden rounded-2xl p-4 hover:-translate-y-3'
+      style={{
+        background: `url(${board.backgroundImageURL}) no-repeat center / cover`,
+      }}
+    >
+      <Link to={`/board/${board.id}`} className='flex h-full w-full flex-col justify-end'>
+        <div className='board-card-inner flex h-[136px] flex-col items-start justify-between p-3'>
+          <h4 className='h-[26px] w-full text-bold-20'>{board.name}</h4>
+          <MemberList memberList={board.recentMessages} memberCount={board.messageCount} />
+          <TopReactionList topReactions={board.topReactions} />
+        </div>
+      </Link>
+    </article>
+  );
+};
+
+export default BoardCard;

--- a/src/components/pages/boardList/BoardCardListSkeleton.tsx
+++ b/src/components/pages/boardList/BoardCardListSkeleton.tsx
@@ -1,0 +1,15 @@
+import { BoardCardSkeleton } from 'mingle-ui';
+
+const BoardCardListSkeleton = () => {
+  return (
+    <ul className='flex flex-row gap-5'>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <li key={`card-skeleton-${index}`}>
+          <BoardCardSkeleton />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default BoardCardListSkeleton;

--- a/src/components/pages/boardList/EmptyBoardCards.tsx
+++ b/src/components/pages/boardList/EmptyBoardCards.tsx
@@ -1,0 +1,15 @@
+import { EmptyBoardCard } from 'mingle-ui';
+
+const EmptyBoardCards = () => {
+  return (
+    <ul className='flex flex-row gap-5'>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <li key={`empty-board-cards-${index}`}>
+          <EmptyBoardCard />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default EmptyBoardCards;

--- a/src/components/pages/boardList/EmptyEmoji.tsx
+++ b/src/components/pages/boardList/EmptyEmoji.tsx
@@ -1,0 +1,9 @@
+const EmptyEmoji = () => {
+  return (
+    <div className='flexbox-row-center w-full rounded-full py-2 color-background-opacity-white-10'>
+      <span className='text-bold-12'>No Emotions</span>
+    </div>
+  );
+};
+
+export default EmptyEmoji;

--- a/src/components/pages/boardList/EmptyMember.tsx
+++ b/src/components/pages/boardList/EmptyMember.tsx
@@ -1,0 +1,5 @@
+const EmptyMember = () => {
+  return <span className='grow text-base-13 opacity-60 color-text-primary'>No Members</span>;
+};
+
+export default EmptyMember;

--- a/src/components/pages/boardList/MemberList.tsx
+++ b/src/components/pages/boardList/MemberList.tsx
@@ -1,0 +1,55 @@
+import { SVGS } from '@/constants';
+
+import EmptyMember from '@/components/pages/boardList/EmptyMember';
+import { MessagesResults } from '@/types/recipients';
+
+const {
+  members: { url, alt },
+} = SVGS;
+
+interface MemberListProps {
+  memberList: MessagesResults[];
+  memberCount: number;
+}
+
+const MemberList = ({ memberList, memberCount }: MemberListProps) => {
+  const MIN_MEMBER_COUNT = 3;
+  const isMemberEmpty = memberCount === 0;
+
+  return (
+    <div className='flexbox-row justify-start gap-3'>
+      <img className='pl-2' src={url} alt={alt} />
+      <span className='h-6 w-px border border-white opacity-10'></span>
+
+      {isMemberEmpty ? (
+        <EmptyMember />
+      ) : (
+        <ul className='flex gap-2'>
+          {memberList.map((member) => (
+            <li key={member.id}>
+              <div
+                className='size-8 overflow-hidden rounded-full color-background-opacity-white-10'
+                style={{
+                  backgroundImage: `url(${member.profileImageURL})`,
+                  backgroundRepeat: 'no-repeat',
+                  backgroundSize: 'cover',
+                  backgroundPosition: 'center center',
+                }}
+              ></div>
+            </li>
+          ))}
+
+          {memberCount > MIN_MEMBER_COUNT && (
+            <li>
+              <div className='flexbox-row-center size-8 rounded-full color-background-opacity-white-10'>
+                <span className='text-bold-12'>{memberCount - MIN_MEMBER_COUNT}+</span>
+              </div>
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default MemberList;

--- a/src/components/pages/boardList/MemberList.tsx
+++ b/src/components/pages/boardList/MemberList.tsx
@@ -17,8 +17,8 @@ const MemberList = ({ memberList, memberCount }: MemberListProps) => {
   const isMemberEmpty = memberCount === 0;
 
   return (
-    <div className='flexbox-row justify-start gap-3'>
-      <img className='pl-2' src={url} alt={alt} />
+    <div className='flexbox-row justify-start gap-2'>
+      <img className='pl-1' src={url} alt={alt} />
       <span className='h-6 w-px border border-white opacity-10'></span>
 
       {isMemberEmpty ? (

--- a/src/components/pages/boardList/TopReactionList.tsx
+++ b/src/components/pages/boardList/TopReactionList.tsx
@@ -1,0 +1,25 @@
+import { BadgeEmoji } from 'mingle-ui';
+
+import { EmojiResults } from '@/types/recipients';
+
+import EmptyEmoji from './EmptyEmoji';
+
+interface TopReactionListProps {
+  topReactions: EmojiResults[];
+}
+
+const TopReactionList = ({ topReactions }: TopReactionListProps) => {
+  const isReactionEmpty = topReactions.length === 0;
+  return (
+    <ul className='flex w-full gap-2'>
+      {topReactions.map(({ id, emoji, count }: EmojiResults) => (
+        <li key={`emoji-badge-${id}`}>
+          <BadgeEmoji emoji={emoji} count={count} />
+        </li>
+      ))}
+      {isReactionEmpty && <EmptyEmoji />}
+    </ul>
+  );
+};
+
+export default TopReactionList;

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -123,4 +123,14 @@ export const SVGS = {
     url: `${CLOUDFLARE_URL}/979d6cac-f641-43ab-5c99-922d45373e00/${ICON_SIZE_20}`,
     alt: 'members icon',
   },
+  arrow: {
+    left: {
+      url: `${CLOUDFLARE_URL}/517fe462-7bfb-4ba9-b2cd-65e9474aca00/${ICON_SIZE_20}`,
+      alt: 'arrow left icon',
+    },
+    right: {
+      url: `${CLOUDFLARE_URL}/c3e8443f-b224-4b4e-8ea4-8747db312c00/${ICON_SIZE_20}`,
+      alt: 'arrow right icon',
+    },
+  },
 };

--- a/src/index.css
+++ b/src/index.css
@@ -41,6 +41,7 @@
     border-radius: 12px;
     background: rgba(0, 0, 0, 0.3);
     backdrop-filter: blur(30px);
+    width: 100%;
   }
 
   .header-background {

--- a/src/index.css
+++ b/src/index.css
@@ -97,6 +97,13 @@
     align-items: start;
   }
 
+  .flexbox-column-between {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: start;
+  }
+
   .flexbox-row {
     display: flex;
     flex-direction: row;

--- a/src/pages/BoardList/data-access/useGetBoardList.ts
+++ b/src/pages/BoardList/data-access/useGetBoardList.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getBoardList } from '@/api/queryFunctions';
+import { BoardListParams } from '@/types/recipients';
+
+export const useGetBoardList = ({ sort, limit }: BoardListParams) => {
+  const { data, isLoading } = useQuery({
+    queryKey: ['recipients', sort, limit],
+    queryFn: () => getBoardList({ sort, limit }),
+  });
+
+  return { data, isLoading };
+};

--- a/src/pages/BoardList/index.tsx
+++ b/src/pages/BoardList/index.tsx
@@ -1,0 +1,123 @@
+import { useRef, useState } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { IconButton } from 'mingle-ui';
+
+import { SVGS } from '@/constants';
+
+import { getBoardList } from '@/api/queryFunctions';
+import BoardCard from '@/components/pages/boardList/BoardCard';
+import Header from '@/components/ui/Header';
+import { BoardResults } from '@/types/recipients';
+
+const {
+  arrow: { left, right },
+  search,
+} = SVGS;
+
+const SCROLL_SLIDER_WIDRH = 1140;
+
+const BoardList = () => {
+  const { data: popularBoardData } = useQuery({
+    queryKey: ['recipients', 'like'],
+    queryFn: getBoardList,
+  });
+
+  const { data: latestBoardData } = useQuery({
+    queryKey: ['recipients', '', 99],
+    queryFn: getBoardList,
+  });
+
+  const sliderRef = useRef<HTMLDivElement>(null);
+  const [isFocused, setIsFocused] = useState(false);
+
+  const handleFocus = () => setIsFocused(true);
+  const handleBlur = () => setIsFocused(false);
+
+  const handleNextClick = () => {
+    if (sliderRef.current) {
+      sliderRef.current.scrollLeft += SCROLL_SLIDER_WIDRH;
+    }
+  };
+
+  const handlePrevClick = () => {
+    if (sliderRef.current) {
+      sliderRef.current.scrollLeft -= SCROLL_SLIDER_WIDRH;
+    }
+  };
+
+  return (
+    <div>
+      <Header />
+      <main className='m-auto flex max-w-[1120px] flex-col gap-4 py-[100px] pl-5 lg:pl-0'>
+        <section className='popular-board'>
+          <div className='flex justify-between'>
+            <h2 className='mb-2 text-bold-24 text-yellow-300'>Popular Board</h2>
+            <div className='flex gap-2'>
+              <IconButton
+                iconAlt={left.alt}
+                iconUrl={left.url}
+                variant='stroke'
+                onClick={handlePrevClick}
+                iconSize={24}
+              />
+              <IconButton
+                iconAlt={right.alt}
+                iconUrl={right.url}
+                variant='stroke'
+                onClick={handleNextClick}
+                iconSize={24}
+              />
+            </div>
+          </div>
+
+          <div className='max-w-[1120px] overflow-x-scroll scroll-smooth pt-5 scrollbar-hide' ref={sliderRef}>
+            <ul className='flex flex-row gap-5'>
+              {popularBoardData?.map((board: BoardResults) => (
+                <li key={board.id}>
+                  <BoardCard board={board} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className='latest-board'>
+          <div className='mt-10 flex items-center justify-between'>
+            <h2 className='mb-2 text-bold-24 text-green-400'>Latest Board</h2>
+            <div className='flex items-center gap-4'>
+              <label htmlFor='search'>
+                <img
+                  src={isFocused ? search.active.url : search.default.url}
+                  alt={isFocused ? search.active.alt : search.default.alt}
+                  width={24}
+                  height={24}
+                />
+              </label>
+              <input
+                id='search'
+                type='text'
+                placeholder='Find Your Mingle Board'
+                className='w-[210px] bg-transparent text-base-18 text-neutral-100 outline-none placeholder:text-neutral-700'
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+              />
+            </div>
+          </div>
+
+          <div className='max-w-[1120px] overflow-x-scroll scroll-smooth pt-5 scrollbar-hide'>
+            <ul className='grid grid-cols-4 gap-x-5 gap-y-8'>
+              {latestBoardData?.map((board: BoardResults) => (
+                <li key={board.id}>
+                  <BoardCard board={board} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default BoardList;

--- a/src/pages/BoardList/index.tsx
+++ b/src/pages/BoardList/index.tsx
@@ -1,14 +1,16 @@
 import { useRef, useState } from 'react';
 
-import { useQuery } from '@tanstack/react-query';
-import { IconButton } from 'mingle-ui';
+import { EmptyBoardCard, IconButton } from 'mingle-ui';
 
 import { SVGS } from '@/constants';
 
-import { getBoardList } from '@/api/queryFunctions';
 import BoardCard from '@/components/pages/boardList/BoardCard';
+import BoardCardListSkeleton from '@/components/pages/boardList/BoardCardListSkeleton';
+import EmptyBoardCards from '@/components/pages/boardList/EmptyBoardCards';
 import Header from '@/components/ui/Header';
 import { BoardResults } from '@/types/recipients';
+
+import { useGetBoardList } from './data-access/useGetBoardList';
 
 const {
   arrow: { left, right },
@@ -18,18 +20,25 @@ const {
 const SCROLL_SLIDER_WIDRH = 1140;
 
 const BoardList = () => {
-  const { data: popularBoardData } = useQuery({
-    queryKey: ['recipients', 'like'],
-    queryFn: getBoardList,
-  });
-
-  const { data: latestBoardData } = useQuery({
-    queryKey: ['recipients', '', 99],
-    queryFn: getBoardList,
-  });
+  const { data: popularBoardData, isLoading: isBoardLoading } = useGetBoardList({ sort: 'like' });
+  const { data: latestBoardData } = useGetBoardList({ limit: 99 });
 
   const sliderRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
   const [isFocused, setIsFocused] = useState(false);
+  const [keyword, setKeyword] = useState('');
+
+  const handleChange = () => {
+    if (searchRef.current !== null) {
+      setKeyword(searchRef.current.value);
+    }
+  };
+
+  const filteredBoard =
+    latestBoardData?.filter(({ name }: BoardResults) => name.toLowerCase().includes(keyword.toLowerCase())) ?? [];
+
+  const isPopularBoardEmpty = popularBoardData?.length === 0;
+  const isLatestBoardEmpty = filteredBoard.length === 0;
 
   const handleFocus = () => setIsFocused(true);
   const handleBlur = () => setIsFocused(false);
@@ -52,39 +61,48 @@ const BoardList = () => {
       <main className='m-auto flex max-w-[1120px] flex-col gap-4 py-[100px] pl-5 lg:pl-0'>
         <section className='popular-board'>
           <div className='flex justify-between'>
-            <h2 className='mb-2 text-bold-24 text-yellow-300'>Popular Board</h2>
-            <div className='flex gap-2'>
-              <IconButton
-                iconAlt={left.alt}
-                iconUrl={left.url}
-                variant='stroke'
-                onClick={handlePrevClick}
-                iconSize={24}
-              />
-              <IconButton
-                iconAlt={right.alt}
-                iconUrl={right.url}
-                variant='stroke'
-                onClick={handleNextClick}
-                iconSize={24}
-              />
-            </div>
+            <h2 className='mb-2 text-bold-24 text-yellow-200'>🎉 Popular Board</h2>
+            {popularBoardData?.length > 4 && (
+              <div className='flex gap-2'>
+                <IconButton
+                  iconAlt={left.alt}
+                  iconUrl={left.url}
+                  variant='stroke'
+                  onClick={handlePrevClick}
+                  iconSize={24}
+                />
+                <IconButton
+                  iconAlt={right.alt}
+                  iconUrl={right.url}
+                  variant='stroke'
+                  onClick={handleNextClick}
+                  iconSize={24}
+                />
+              </div>
+            )}
           </div>
 
           <div className='max-w-[1120px] overflow-x-scroll scroll-smooth pt-5 scrollbar-hide' ref={sliderRef}>
-            <ul className='flex flex-row gap-5'>
-              {popularBoardData?.map((board: BoardResults) => (
-                <li key={board.id}>
-                  <BoardCard board={board} />
-                </li>
-              ))}
-            </ul>
+            {isBoardLoading ? (
+              <BoardCardListSkeleton />
+            ) : (
+              <>
+                {isPopularBoardEmpty && <EmptyBoardCards />}
+                <ul className='flex flex-row gap-5'>
+                  {popularBoardData?.map((board: BoardResults) => (
+                    <li key={board.id}>
+                      <BoardCard board={board} />
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
           </div>
         </section>
 
         <section className='latest-board'>
           <div className='mt-10 flex items-center justify-between'>
-            <h2 className='mb-2 text-bold-24 text-green-400'>Latest Board</h2>
+            <h2 className='mb-2 text-bold-24'>Latest Board</h2>
             <div className='flex items-center gap-4'>
               <label htmlFor='search'>
                 <img
@@ -99,20 +117,30 @@ const BoardList = () => {
                 type='text'
                 placeholder='Find Your Mingle Board'
                 className='w-[210px] bg-transparent text-base-18 text-neutral-100 outline-none placeholder:text-neutral-700'
+                onChange={handleChange}
+                value={keyword}
                 onFocus={handleFocus}
                 onBlur={handleBlur}
+                ref={searchRef}
               />
             </div>
           </div>
 
           <div className='max-w-[1120px] overflow-x-scroll scroll-smooth pt-5 scrollbar-hide'>
-            <ul className='grid grid-cols-4 gap-x-5 gap-y-8'>
-              {latestBoardData?.map((board: BoardResults) => (
-                <li key={board.id}>
-                  <BoardCard board={board} />
-                </li>
-              ))}
-            </ul>
+            {isBoardLoading ? (
+              <BoardCardListSkeleton />
+            ) : (
+              <>
+                {isLatestBoardEmpty && <EmptyBoardCard />}
+                <ul className='grid grid-cols-4 gap-x-5 gap-y-8'>
+                  {filteredBoard?.map((board: BoardResults) => (
+                    <li key={board.id}>
+                      <BoardCard board={board} />
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
           </div>
         </section>
       </main>

--- a/src/pages/DetailBoard/index.tsx
+++ b/src/pages/DetailBoard/index.tsx
@@ -22,7 +22,7 @@ import { useGetBoardData } from '@/pages/DetailBoard/data-access/useGetBoardData
 import { useGetMessages } from '@/pages/DetailBoard/data-access/useGetMessages';
 import { useDeleteBoard } from '@/pages/EditBoard/data-access/useDeleteBoard';
 import { passwordSchema } from '@/pages/EditBoard/schema/passwordSchema';
-import { MessagesResults, PaperCardResults } from '@/types/recipients';
+import { MessagesResults, CardResults } from '@/types/recipients';
 
 const { kakao } = SVGS;
 
@@ -61,7 +61,7 @@ const DetailBoard = ({ isEdit = false }: DetailBoardProps) => {
   const filteredMessages = useMemo(() => {
     if (!messages) return [];
 
-    const filtered = messages.filter((messageData: PaperCardResults) => {
+    const filtered = messages.filter((messageData: CardResults) => {
       return selectedTab === 'all' || messageData.relationship === selectedTab;
     });
 

--- a/src/types/recipients.ts
+++ b/src/types/recipients.ts
@@ -9,7 +9,7 @@ export type PostEmoji = {
   type: string;
 };
 
-export type PaperCardResults = {
+export type CardResults = {
   id: number;
   sender: string;
   relationship: string;
@@ -39,4 +39,9 @@ export type BoardResults = {
   reactionCount: number;
   recentMessages: MessagesResults[];
   topReactions: EmojiResults[];
+};
+
+export type BoardListParams = {
+  sort?: string;
+  limit?: number;
 };

--- a/src/utils/getBackgroundImageUrl.ts
+++ b/src/utils/getBackgroundImageUrl.ts
@@ -1,0 +1,9 @@
+import { formatColorToUrl } from '@/constants/formatColor';
+
+export const getBackgroundImageUrl = (backgroundColor: string, backgroundImageUrl: string) => {
+  if (!backgroundImageUrl && backgroundColor in formatColorToUrl) {
+    return formatColorToUrl[backgroundColor as keyof typeof formatColorToUrl];
+  }
+
+  return backgroundImageUrl;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './getReactionsByDeviceType';
 export * from './splitByDelimiter';
+export * from './getBackgroundImageUrl';


### PR DESCRIPTION
## 유형

- [x] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [ ] 문서 업데이트
- [x] 리팩터링

## 상세 내용

- List Page 구현
- Empty UI 구현: 데이터가 없는 경우를 처리하는 Empty UI를 추가했습니다.
- Skeleton UI 구현: 데이터가 로딩 중일 때 보여줄 Skeleton UI를 구현했습니다.
- TopReactionList 컴포넌트: 상위 3개의 리액션을 표시하는 컴포넌트를 구현했습니다.
- EmptyEmoji 컴포넌트: 데이터가 없을 때 사용할 EmptyEmoji 컴포넌트를 추가했습니다.
- 슬라이더 배너 구현
  : 인기있는 보드 8개를 보여주는 슬라이드 배너 구현하였습니다.
  : 데이터가 없는 경우 슬라이더 버튼 제거 및 Empty UI 제공

### 📌 기능 구현
- useGetBoardList 훅 구현: 인기순과 최신순 데이터를 받아오는 useGetBoardList 훅을 구현했습니다.
- sort와 limit 파라미터를 받아 데이터를 가져오는 쿼리 함수를 수정했습니다.
- 보드 리스트에서 검색어를 기반으로 보드를 필터링하는 기능을 구현했습니다.
- 배경 이미지 URL 유틸 함수 구현: formatColorToUrl을 기반으로 배경 이미지 URL을 반환하는 유틸리티 함수를 구현했습니다.

## 스크린샷
### List Page
<img width="1904" alt="스크린샷 2024-07-08 오후 11 08 47" src="https://github.com/designsoo/mingle/assets/77719310/1e0b4742-e871-42f4-855a-9297cd779f2e">

### 검색
<img width="1904" alt="스크린샷 2024-07-08 오후 11 09 12" src="https://github.com/designsoo/mingle/assets/77719310/ca940991-39bf-4136-84ec-9604abffdc52">

### 조회되는 데이터 없는 경우
<img width="1897" alt="스크린샷 2024-07-08 오후 11 09 23" src="https://github.com/designsoo/mingle/assets/77719310/03b0938a-b18d-49d3-a11a-c296c9cbf7e5">
