### PR TITLE
Hotfix: 무한스크롤 구현 시 lastPageParam을 활용하여 적용하는 방법으로 변경

### DIFF
--- a/src/pages/DetailBoard/data-access/useGetMessages.ts
+++ b/src/pages/DetailBoard/data-access/useGetMessages.ts
@@ -16,8 +16,8 @@ export const useGetMessages = (boardId: number) => {
     queryFn: ({ pageParam }) => getMessages({ boardId, offset: pageParam }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, lastPageParam) => {
-      const nexPageParam = lastPageParam + MESSAGES_PER_PAGE;
-      return lastPage.length < MESSAGES_PER_PAGE ? undefined : nexPageParam;
+      const nextPageParam = lastPageParam + MESSAGES_PER_PAGE;
+      return lastPage.length < MESSAGES_PER_PAGE ? undefined : nextPageParam;
     },
     select: (data) => ({
       pages: data.pages.flatMap((page) => page),

--- a/src/pages/DetailBoard/data-access/useGetMessages.ts
+++ b/src/pages/DetailBoard/data-access/useGetMessages.ts
@@ -2,6 +2,8 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { getMessages } from '@/api/queryFunctions';
 
+const MESSAGES_PER_PAGE = 6;
+
 export const useGetMessages = (boardId: number) => {
   const {
     data: messageData,
@@ -13,9 +15,9 @@ export const useGetMessages = (boardId: number) => {
     queryKey: ['messages', boardId],
     queryFn: ({ pageParam }) => getMessages({ boardId, offset: pageParam }),
     initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages) => {
-      const nexPage = allPages.flat().length;
-      return lastPage.length < 6 ? undefined : nexPage;
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      const nexPageParam = lastPageParam + MESSAGES_PER_PAGE;
+      return lastPage.length < MESSAGES_PER_PAGE ? undefined : nexPageParam;
     },
     select: (data) => ({
       pages: data.pages.flatMap((page) => page),


### PR DESCRIPTION
## 유형

- [ ] UI 구현
- [ ] 기능 구현
- [ ] 버그 해결
- [ ] 문서 업데이트
- [x] 리팩터링

## 상세 내용
- allPages의 길이를 offset으로 적용하는 방법을 lastPageParam을 적용하도록 변경했습니다.
- nexPageParam 변수명을 nextPageParam으로 수정했습니다.(오타)