### PR TITLE
Fix: vercel 배포 시 리프레시 404 오류 해결을 위한 경로 설정 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## 유형

- [ ] UI 구현
- [ ] 기능 구현
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 리팩터링

## 상세 내용

- 하위 URL 접근 시 새로고침할 때 404 오류가 발생하는 문제를 해결하기 위해 vercel.json 파일에 모든 경로를 루트로 리디렉션하는 설정을 추가했습니다.