### PR TITLE
Refactor: zod 스키마 적용, useForm 초기값 설정, 컴포넌트 최적화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "eslint-plugin-react-refresh": "^0.4.7",
         "husky": "^8.0.0",
         "lint-staged": "^15.2.7",
-        "mingle-ui": "^0.5.2",
+        "mingle-ui": "^0.5.5",
         "postcss": "^8.4.38",
         "prettier": "^3.3.2",
         "prettier-plugin-tailwindcss": "^0.6.4",
@@ -5123,9 +5123,9 @@
       }
     },
     "node_modules/mingle-ui": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/mingle-ui/-/mingle-ui-0.5.2.tgz",
-      "integrity": "sha512-j3Bdx+xUgW0sBppiFE5QXKKHSjOcdhwuvoASzKiirn8nBEEXvwktrbOTeWsaH1PbzyRstpUPJsHF0BpeeiYyNg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mingle-ui/-/mingle-ui-0.5.5.tgz",
+      "integrity": "sha512-jLFOt3xrOl9eAlQ+bLVyUhZVuQDZHdn4i8MEqxWomdrqhUK7ox7lYSgg5ot5NNJ9t3R2ykzCT11um+BIfoKaAg==",
       "dev": true,
       "dependencies": {
         "@fontsource/plus-jakarta-sans": "^5.0.20",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react-refresh": "^0.4.7",
     "husky": "^8.0.0",
     "lint-staged": "^15.2.7",
-    "mingle-ui": "^0.5.2",
+    "mingle-ui": "^0.5.5",
     "postcss": "^8.4.38",
     "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.4",

--- a/src/pages/AddCard/index.tsx
+++ b/src/pages/AddCard/index.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Dropdown, InputField, Label, PrimaryButton } from 'mingle-ui';
 import { Controller, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import ReactQuill from 'react-quill';
@@ -19,6 +20,8 @@ import {
   uploadImageCloudflare,
 } from '@/pages/CreateBoard/data-access/cloudflareImageService';
 
+import { addFormSchema } from './schema';
+
 const {
   add: { url, alt },
 } = SVGS;
@@ -34,6 +37,7 @@ const AddCard = () => {
   const recipientId = Number(params.id);
   const methods = useForm<FormData>({
     mode: 'all',
+    resolver: zodResolver(addFormSchema),
   });
 
   const quillRef = useRef<ReactQuill>(null);
@@ -99,6 +103,8 @@ const AddCard = () => {
     postCardMutation({ recipientId, cardForm });
   };
 
+  console.log('errors', errors);
+
   return (
     <>
       <MetaData title='Mingle | Add Card' />
@@ -148,9 +154,8 @@ const AddCard = () => {
                     name='name'
                     type='text'
                     placeholder='Name'
-                    errorMessage='Name is Required'
+                    errorMessage={errors.name?.message}
                     maxLength={13}
-                    isRequired
                     autoComplete='username'
                   />
                   <InputField
@@ -159,6 +164,7 @@ const AddCard = () => {
                     name='password'
                     type='password'
                     placeholder='● ● ● ●'
+                    errorMessage={errors.password?.message}
                     maxLength={4}
                     autoComplete='current-password'
                   />

--- a/src/pages/AddCard/schema/index.tsx
+++ b/src/pages/AddCard/schema/index.tsx
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const addFormSchema = z.object({
+  name: z.string().min(1, 'Name is Required').min(4, 'Please enter at least 4 characters'),
+  password: z
+    .union([
+      z.string().length(4, 'Password must be exactly 4 characters'),
+      z.string().length(0, 'Password must be empty or exactly 4 characters'),
+    ])
+    .optional(),
+  content: z.string().min(1),
+});

--- a/src/pages/CreateBoard/data-access/useCreateBoard.ts
+++ b/src/pages/CreateBoard/data-access/useCreateBoard.ts
@@ -9,8 +9,8 @@ export const useCreateBoard = () => {
   const { mutate: postFormMutation, isPending: isCreateLoading } = useMutation({
     mutationFn: RECIPIENTS.post,
     onSuccess: (response) => {
-      const newBoardUrl = response.data.id;
-      navigate(`/board/${newBoardUrl}`);
+      const boardId = response.data.id;
+      navigate(`/board/${boardId}`);
     },
     onError: () => {
       alert('대시보드 생성에 실패했습니다. 다시 시도해 주세요.');

--- a/src/pages/CreateBoard/index.tsx
+++ b/src/pages/CreateBoard/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { zodResolver } from '@hookform/resolvers/zod';
 import { InputField, PrimaryButton, TabList } from 'mingle-ui';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
@@ -15,6 +16,8 @@ import NavigationBar from '@/components/ui/NavigationBar';
 import { checkUploadStatus, uploadImageCloudflare } from '@/pages/CreateBoard/data-access/cloudflareImageService';
 import { useCreateBoard } from '@/pages/CreateBoard/data-access/useCreateBoard';
 
+import { ceateFormSchema } from './schema';
+
 type FormValues = {
   name: string;
   password?: string;
@@ -24,6 +27,7 @@ type FormValues = {
 
 const CreateBoard = () => {
   const methods = useForm<FormValues>({
+    resolver: zodResolver(ceateFormSchema),
     mode: 'all',
     defaultValues: {
       name: '',
@@ -32,7 +36,12 @@ const CreateBoard = () => {
     },
   });
 
-  const { control, handleSubmit, setValue } = methods;
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = methods;
   const name = useWatch({
     control: control,
     name: 'name',
@@ -101,9 +110,8 @@ const CreateBoard = () => {
                     name='name'
                     type='text'
                     placeholder='Name'
-                    errorMessage='Name is Required'
+                    errorMessage={errors.name?.message}
                     maxLength={10}
-                    isRequired
                     autoComplete='username'
                   />
                   <InputField
@@ -112,6 +120,7 @@ const CreateBoard = () => {
                     name='password'
                     type='password'
                     placeholder='● ● ● ●'
+                    errorMessage={errors.password?.message}
                     maxLength={4}
                     autoComplete='current-password'
                   />

--- a/src/pages/CreateBoard/schema/index.ts
+++ b/src/pages/CreateBoard/schema/index.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const ceateFormSchema = z.object({
+  name: z.string().min(1, 'Name is Required').min(4, 'Please enter at least 4 characters'),
+  password: z
+    .union([
+      z.string().length(4, 'Password must be exactly 4 characters'),
+      z.string().length(0, 'Password must be empty or exactly 4 characters'),
+    ])
+    .optional(),
+  backgroundColor: z.string(),
+  backgroundImageURL: z.union([z.string(), z.null()]),
+});

--- a/src/pages/EditBoard/schema/passwordSchema.ts
+++ b/src/pages/EditBoard/schema/passwordSchema.ts
@@ -6,6 +6,6 @@ export const passwordSchema = (inputValue: string) =>
   z.object({
     password: z
       .string()
-      .min(MIN_PASSWORD_LENGTH, 'The password must be four digits.')
+      .min(MIN_PASSWORD_LENGTH, 'Password must be exactly 4 characters')
       .refine((val) => val === inputValue, { message: 'The password does not match.' }),
   });


### PR DESCRIPTION
## 유형

- [ ] UI 구현
- [ ] 기능 구현
- [ ] 버그 해결
- [ ] 문서 업데이트
- [x] 리팩터링

## 상세 내용
- Create, Add 페이지의 폼 관련 zod schema를 재적용했습니다.
- `useForm`의 `defaultValues`를 설정하여 불필요한 초기 폼 상태를 삭제했습니다.
- 비밀번호 4자리가 아닐 때 표시되는 에러 메시지를 "Password must be exactly 4 characters"로 수정했습니다.
- Create 페이지의 `handleImageClick`, `onSubmit` 함수에 `useCallback`을 적용하여 불필요한 렌더링을 최적화했습니다.